### PR TITLE
fix(android popup instantiation): enable design customization

### DIFF
--- a/src/menu.android.ts
+++ b/src/menu.android.ts
@@ -9,7 +9,7 @@ export class Menu extends Common {
     return new Promise((resolve, reject) => {
       try {
         let popupMenu = new android.widget.PopupMenu(
-          app.android.context,
+          app.android.foregroundActivity,
           options.view.android
         );
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
It's impossible to apply android styles to popup. 
There was a request (#1) to implement mechanism to change default look.
Although such an implementation is impossible or really challenging due to popups' nature, Android provides means to style them. Here's a simple example:

res/values/styles.xml
   ```
    <style name="AppTheme" parent="AppThemeBase">       
        <item name="android:popupMenuStyle">@style/PopupMenu</item>      
    </style>    
    <style name="PopupMenu" parent="@android:style/Widget.PopupMenu">    
        <item name="android:popupBackground">#fbae17</item>    
    </style>
```
An Activity(instead of Application) class should be passed to PopupMenu constructor in order to apply this style. 


## What is the new behavior?
Popup styles take effect.

Fixes/Implements/Closes #1 .

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->